### PR TITLE
Fixed [walton] version error

### DIFF
--- a/lib/extension_scanner.rb
+++ b/lib/extension_scanner.rb
@@ -147,8 +147,12 @@ class ExtensionScanner < Scanner
     extensions.each do |e|
       queue_requests(e['name']) do |resp, extension_path, manifest_uri|
         lock.synchronize do
-          res = process_result(e, extension_path, manifest_uri, resp.body)
-          detected.push(res) if res[:vulns].length > 0
+          begin
+            res = process_result(e, extension_path, manifest_uri, resp.body)
+            detected.push(res) if res[:vulns].length > 0
+          rescue
+            #puts "Version of module " + e['name'].to_str + " couldn't be determined"
+          end
         end
       end
     end


### PR DESCRIPTION
Fixed an issue where the Ruby::Version gem was taking a non-version input. This was due to the manifest returning [Walton] instead of the version number of the component, which caused the program to crash. Now, there is a begin and rescue statement. 
